### PR TITLE
Use same maven-compiler-plugin configuration as in Cyberduck.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>8</maven.compiler.release>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 
 		<!-- dependencies -->
 		<gson.version>2.11.0</gson.version>
@@ -181,8 +182,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
+					<release>${maven.compiler.target}</release>
 					<encoding>UTF-8</encoding>
 					<showWarnings>true</showWarnings>
 				</configuration>

--- a/src/main/java/org/cryptomator/cryptolib/v3/FileContentCryptorImpl.java
+++ b/src/main/java/org/cryptomator/cryptolib/v3/FileContentCryptorImpl.java
@@ -133,7 +133,6 @@ class FileContentCryptorImpl implements FileContentCryptor {
 
 			// payload:
 			final ByteBuffer payloadBuf = ciphertextChunk.duplicate();
-			payloadBuf.position(GCM_NONCE_SIZE);
 			assert payloadBuf.remaining() >= GCM_TAG_SIZE;
 
 			// payload:


### PR DESCRIPTION
Fixed dropped change while merging commits from upstream: https://github.com/cryptomator/cryptolib/commit/1170de4f4c63cd8fba9eee7903f5abc29acd8105#diff-c248045c1b0084eb1df902d59250681c544711cac37e1246907c20171636a0ec